### PR TITLE
adding requirements.txt with versions that work

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ The following snippets provide references for regenerating PHI-ML and training n
 
 #### Dependencies
 ```
-pip install requests bs4 coloredlogs dm-sonnet editdistance lxml nltk tensor2tensor tensorflow-gpu tqdm && \
-python -m nltk.downloader punkt
+pip install -r requirements.txt && \
+python -m nltk.downloader punkts
 ```
 
 #### PHI-ML dataset generation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+requests==2.22.0
+bs4==0.0.1
+coloredlogs==10.0
+dm-sonnet==1.23
+editdistance==0.5.3
+lxml==4.4.1
+nltk==3.4.5
+tensor2tensor==1.14.1
+tensorflow-gpu==1.14.0
+tqdm==4.36.1


### PR DESCRIPTION
I pulled the repo and found the default library installs didn't work. 
Attached to this PR is a requirements.txt file with pinned versions that work. 
I verified this by training for 50 epochs and checking the results.